### PR TITLE
Fix on characteristic changed

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <writeAnnotations>

--- a/BluetoothLELib/src/main/java/com/example/bluetoothlelib/BluetoothLE.java
+++ b/BluetoothLELib/src/main/java/com/example/bluetoothlelib/BluetoothLE.java
@@ -252,17 +252,19 @@ public class BluetoothLE {
 
         @Override
         public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
-            unityDebugMessage("onCharacteristicChanged");
+//            unityDebugMessage("onCharacteristicChanged");
             byte[] data = characteristic.getValue();
             StringBuilder receiveData = new StringBuilder();
 
             // 必要であればデータの処理を行う
             for (byte i : data){
+//                unityDebugMessage(new String(i));
                 receiveData.append(String.valueOf(i));
 //                unityDebugMessage(String.valueOf(i));
             }
 //            unityDebugMessage(receiveData + "\n");
-            unitySendMessage("onCharacteristicChanged", receiveData + "\n");
+//            unitySendMessage("onCharacteristicChanged", receiveData + "\n");
+            unitySendMessage("onCharacteristicChanged", new String(data).replace(",", " ，"));
         }
     };
 

--- a/BluetoothLELib/src/main/java/com/example/bluetoothlelib/BluetoothLE.java
+++ b/BluetoothLELib/src/main/java/com/example/bluetoothlelib/BluetoothLE.java
@@ -254,14 +254,14 @@ public class BluetoothLE {
         public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
             unityDebugMessage("onCharacteristicChanged");
             byte[] data = characteristic.getValue();
-//            StringBuilder receiveData = new StringBuilder();
+            StringBuilder receiveData = new StringBuilder();
 
             // 必要であればデータの処理を行う
             for (byte i : data){
-//                receiveData.append(String.valueOf(i));
-                unityDebugMessage(String.valueOf(i));
+                receiveData.append(String.valueOf(i));
+//                unityDebugMessage(String.valueOf(i));
             }
-//            unityDebugMessage(receiveData + "\n");
+            unityDebugMessage(receiveData + "\n");
         }
     };
 

--- a/BluetoothLELib/src/main/java/com/example/bluetoothlelib/BluetoothLE.java
+++ b/BluetoothLELib/src/main/java/com/example/bluetoothlelib/BluetoothLE.java
@@ -261,7 +261,8 @@ public class BluetoothLE {
                 receiveData.append(String.valueOf(i));
 //                unityDebugMessage(String.valueOf(i));
             }
-            unityDebugMessage(receiveData + "\n");
+//            unityDebugMessage(receiveData + "\n");
+            unitySendMessage("onCharacteristicChanged", receiveData + "\n");
         }
     };
 


### PR DESCRIPTION
# onCharacteristicChangedコールバックでunityに渡すUwbDataをUnity側で使える形に修正

変にデコードしようとしてむちゃくちゃになってたけど、普通にStringへparseすれば素直にデータが受け取れた。
pythonソースだとバイナリ形式を受け取って、デコードしてから使える形にしていたけど、そっちの方がパフォーマンスは良さそうで設計としてもいいと思うから余裕があれば対応したい